### PR TITLE
refactor: 패키지 및 앱아이디 수정 expbox.app -> expbox

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    namespace 'com.dgparkcode.expbox.app'
+    namespace 'com.dgparkcode.expbox'
     compileSdk 33
 
     defaultConfig {
-        applicationId "com.dgparkcode.expbox.app"
+        applicationId "com.dgparkcode.expbox"
         minSdk 21
         targetSdk 33
         versionCode 1

--- a/app/src/androidTest/java/com/dgparkcode/expbox/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/dgparkcode/expbox/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.dgparkcode.expbox.app
+package com.dgparkcode.expbox
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Expboxaos">
         <activity
-            android:name=".MainActivity"
+            android:name="com.dgparkcode.expbox.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/dgparkcode/expbox/MainActivity.kt
+++ b/app/src/main/java/com/dgparkcode/expbox/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.dgparkcode.expbox.app
+package com.dgparkcode.expbox
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context="com.dgparkcode.expbox.MainActivity">
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/test/java/com/dgparkcode/expbox/ExampleUnitTest.kt
+++ b/app/src/test/java/com/dgparkcode/expbox/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.dgparkcode.expbox.app
+package com.dgparkcode.expbox
 
 import org.junit.Test
 


### PR DESCRIPTION
모듈에 클린 아키텍처의 형태로 패키지를 구성하려는데,
app 이란 엔드 포인트는 어울리지 않아 개발 초기인 지금 바꾸는 것이 좋다.